### PR TITLE
Add missing readResolve() method in serialization proxy example

### DIFF
--- a/src/effectivejava/chapter12/item90/Period.java
+++ b/src/effectivejava/chapter12/item90/Period.java
@@ -43,6 +43,10 @@ public final class Period implements Serializable {
 
         private static final long serialVersionUID =
                 234098243823485285L; // Any number will do (Item 87)
+
+        private Object readResolve() {
+            return new Period(start, end); // Uses public constructor
+        }
     }
 
     // writeReplace method for the serialization proxy pattern


### PR DESCRIPTION
In Item #90, the `readResolve()` method in the `SerializationProxy` class is mentioned in the book but it's missing in the source code.